### PR TITLE
Update withIpBlock2-networkpolicy5.yaml

### DIFF
--- a/tests/example_policies/withIpBlock2/withIpBlock2-networkpolicy5.yaml
+++ b/tests/example_policies/withIpBlock2/withIpBlock2-networkpolicy5.yaml
@@ -5,7 +5,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54
+  name: enable-from-kube-system-tier-frontend-to-ipblock-high-addresses-on-ports-53-54
   namespace: kube-system
 spec:
   podSelector:
@@ -30,7 +30,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different1-expect-bigger
+  name: enable-from-kube-system-tier-frontend-to-ipblock-high-addresses-on-ports-53-54-slightly-different1-expect-bigger
   namespace: kube-system
 spec:
   podSelector:
@@ -71,7 +71,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different2-excpect-smaller
+  name: enable-from-kube-system-tier-frontend-to-ipblock-high-addresses-on-ports-53-54-slightly-different2-excpect-smaller
   namespace: kube-system
 spec:
   podSelector:
@@ -112,7 +112,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different3-port-added
+  name: enable-from-kube-system-tier-frontend-to-ipblock-high-addresses-on-ports-53-54-slightly-different3-port-added
   namespace: kube-system
 spec:
   podSelector:
@@ -155,7 +155,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different4-port-reduced
+  name: enable-from-kube-system-tier-frontend-to-ipblock-high-addresses-on-ports-53-54-slightly-different4-port-reduced
   namespace: kube-system
 spec:
   podSelector:


### PR DESCRIPTION
running this on k8s cluster gives "invalid metadata name errors" (Error from server (Invalid): error when creating "C:/Users/ShireenFalah/Desktop/yaml_files/tests_failed_not_mine/failed9_github.yml": NetworkPolicy.extensions "enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54" is invalid: metadata.name: Invalid value: "enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
Error from server (Invalid): error when creating "C:/Users/ShireenFalah/Desktop/yaml_files/tests_failed_not_mine/failed9_github.yml": NetworkPolicy.extensions "enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different1-expect-bigger" is invalid: metadata.name: Invalid value: "enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different1-expect-bigger": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
Error from server (Invalid): error when creating "C:/Users/ShireenFalah/Desktop/yaml_files/tests_failed_not_mine/failed9_github.yml": NetworkPolicy.extensions "enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different2-excpect-smaller" is invalid: metadata.name: Invalid value: "enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different2-excpect-smaller": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
Error from server (Invalid): error when creating "C:/Users/ShireenFalah/Desktop/yaml_files/tests_failed_not_mine/failed9_github.yml": NetworkPolicy.extensions "enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different3-port-added" is invalid: metadata.name: Invalid value: "enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different3-port-added": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
Error from server (Invalid): error when creating "C:/Users/ShireenFalah/Desktop/yaml_files/tests_failed_not_mine/failed9_github.yml": NetworkPolicy.extensions "enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different4-port-reduced" is invalid: metadata.name: Invalid value: "enable-from-kube-system-tier-frontend-to-ipBlock-high-addresses-on-ports-53-54-slightly-different4-port-reduced": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
)
As we are following k8s now, I have changed the names to fit the regex