### PR TITLE
Avoid printing "X is not supported"

### DIFF
--- a/network-config-analyzer/PeerContainer.py
+++ b/network-config-analyzer/PeerContainer.py
@@ -162,7 +162,7 @@ class PeerContainer:
             self.add_eps_from_list(peer_code)
 
         print(f'{config_name}: cluster has {self.get_num_peers()} unique endpoints, '
-              '{self.get_num_namespaces()} namespaces')
+              f'{self.get_num_namespaces()} namespaces')
 
     def _set_namespace_list_from_github(self, url):
         """
@@ -404,8 +404,6 @@ class PeerContainer:
                 self._add_networkset_from_yaml(networkset)
         elif kind in ['NetworkSet', 'GlobalNetworkSet']:
             self._add_networkset_from_yaml(ep_list)
-        else:
-            print(kind, ' is not supported ', file=stderr)
 
     def delete_all_peers(self):
         self.peer_set.clear()


### PR DESCRIPTION
This creates a lot of noise when scanning yamls with resources that are not relevant for us