### PR TITLE
Added a draft workflow for building and pushing NCA docker image

### DIFF
--- a/.github/workflows/build-push-NCA-container.yml
+++ b/.github/workflows/build-push-NCA-container.yml
@@ -1,0 +1,32 @@
+name: Build and push NCA docker image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: my-docker-hub-namespace/my-docker-hub-repository
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I added a new draft workflow for automatically building an NCA docker image. This workflow is activated manually (no danger of automatic activation by push). In order to debug it, I need it to exist in the master. After merging, I will continue to work in the branch and to fix the workflow.
