### PR TITLE
switch to python-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,15 @@
 # SPDX-License-Identifier: Apache2.0
 #
 
-FROM python:3.8-alpine
+FROM python:3.8-slim
 
 RUN python -m pip install -U pip wheel setuptools
 COPY requirements.txt /nca/
 RUN pip install -r /nca/requirements.txt
 
-RUN apk add --no-cache curl
+RUN apt-get update && apt-get install curl -y
 
-RUN curl -L https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/linux/amd64/kubectl --output /usr/local/bin/kubectl
+RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" --output /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl
 
 RUN curl -L https://github.com/projectcalico/calicoctl/releases/download/v3.3.1/calicoctl --output /usr/local/bin/calicoctl
@@ -19,7 +19,6 @@ RUN chmod +x /usr/local/bin/calicoctl
 
 COPY network-config-analyzer/ /nca/
 
-RUN addgroup -S ncagroup && adduser -S ncauser -G ncagroup
-USER ncauser
+USER 9000
 
 ENTRYPOINT ["python", "/nca/nca.py"]


### PR DESCRIPTION
Changes:
- Switched base image to `python-slim:3.8`, which is basically Debian Linux
- Using `apt-get` instead of `apk add` because this is the package manager in Debian
- Always downloading the latest version of `kubectl`
- Setting non-root user by simply setting the user to `9000`. No need for a new user-group and so.