### PR TITLE
compute_query_output fixes

### DIFF
--- a/network-config-analyzer/NetworkConfigQuery.py
+++ b/network-config-analyzer/NetworkConfigQuery.py
@@ -132,7 +132,7 @@ class EmptinessQuery(NetworkConfigQuery):
                            full_explanation, res)
 
     def compute_query_output(self, query_answer):
-        return self.get_query_output(query_answer, query_answer.bool_result)
+        return self.get_query_output(query_answer, add_explanation=query_answer.bool_result)
 
 
 class VacuityQuery(NetworkConfigQuery):
@@ -237,7 +237,7 @@ class RedundancyQuery(NetworkConfigQuery):
         return QueryAnswer(False, 'No redundancy found in ' + self.config.name)
 
     def compute_query_output(self, query_answer):
-        return self.get_query_output(query_answer, query_answer.bool_result)
+        return self.get_query_output(query_answer, add_explanation=query_answer.bool_result)
 
 
 class SanityQuery(NetworkConfigQuery):
@@ -533,7 +533,7 @@ class ConnectivityMapQuery(NetworkConfigQuery):
         return res
 
     def compute_query_output(self, query_answer):
-        return self.get_query_output(query_answer, query_answer.bool_result)
+        return self.get_query_output(query_answer, only_explanation=query_answer.bool_result)
 
     @staticmethod
     def filter_istio_edge(peer2, conns):
@@ -938,8 +938,7 @@ class SemanticDiffQuery(TwoNetworkConfigsQuery):
         query_output = ''
         if self.output_config.outputFormat == 'txt':
             query_output += query_answer.output_result
-        if not query_answer.bool_result:
-            query_output += query_answer.output_explanation
+        query_output += query_answer.output_explanation
         return res, query_output
 
 
@@ -1047,7 +1046,7 @@ class TwoWayContainmentQuery(TwoNetworkConfigsQuery):
         explanation_not_contained_other_self = \
             contained_2_in_1.output_result + ':\n\t' + contained_2_in_1.output_explanation
         if contained_1_in_2.bool_result and contained_2_in_1.bool_result:
-            return QueryAnswer(bool_result=False,
+            return QueryAnswer(bool_result=True,
                                output_result=f'The two network configurations {self.name1} and {self.name2} '
                                              'are semantically equivalent.',
                                numerical_result=3)
@@ -1185,7 +1184,7 @@ class IntersectsQuery(TwoNetworkConfigsQuery):
                     return QueryAnswer(True, self.name2 + ' intersects with ' + self.name1, output_explanation)
 
         return QueryAnswer(False, f'The connections allowed by {self.name1}'
-                                  f' do not intersect the connections allowed by {self.name2}')
+                                  f' do not intersect the connections allowed by {self.name2}', numerical_result=1)
 
 
 class ForbidsQuery(TwoNetworkConfigsQuery):
@@ -1196,13 +1195,15 @@ class ForbidsQuery(TwoNetworkConfigsQuery):
                                       'No traffic is specified as forbidden.')
         return IntersectsQuery(self.config1, self.config2).exec(True)
 
-    def compute_query_output(self, query_answer, _):
-        if query_answer.bool_result:
-            query_output = f'{self.config2.name} does not forbid connections specified in {self.config1.name}:' \
+    def compute_query_output(self, query_answer, cmd_line_flag=False):
+        res = not query_answer.numerical_result if cmd_line_flag else query_answer.bool_result
+        query_output = query_answer.output_result + '\n'
+        if query_answer.numerical_result == 0:
+            query_output += f'{self.config2.name} does not forbid connections specified in {self.config1.name}:' \
                            f'{query_answer.output_explanation}'
         else:
-            query_output = f'{self.config2.name} forbids connections specified in {self.config1.name}'
-        return query_answer.bool_result, query_output
+            query_output += f'{self.config2.name} forbids connections specified in {self.config1.name}'
+        return res, query_output
 
 
 class AllCapturedQuery(NetworkConfigQuery):

--- a/network-config-analyzer/NetworkConfigQuery.py
+++ b/network-config-analyzer/NetworkConfigQuery.py
@@ -129,7 +129,7 @@ class EmptinessQuery(NetworkConfigQuery):
         full_explanation = '\n'.join(full_explanation_list)
         return QueryAnswer(res > 0,
                            'There are empty NetworkPolicies and/or empty ingress/egress rules in ' + self.config.name,
-                           full_explanation, res)
+                           '\n' + full_explanation, res)
 
     def compute_query_output(self, query_answer):
         return self.get_query_output(query_answer, add_explanation=query_answer.bool_result)

--- a/network-config-analyzer/NetworkConfigQuery.py
+++ b/network-config-analyzer/NetworkConfigQuery.py
@@ -1200,7 +1200,7 @@ class ForbidsQuery(TwoNetworkConfigsQuery):
         query_output = query_answer.output_result + '\n'
         if query_answer.numerical_result == 0:
             query_output += f'{self.config2.name} does not forbid connections specified in {self.config1.name}: ' \
-                        f'{query_answer.output_explanation}'
+                f'{query_answer.output_explanation}'
         else:
             query_output += f'{self.config2.name} forbids connections specified in {self.config1.name}'
         return res, query_output

--- a/network-config-analyzer/NetworkConfigQuery.py
+++ b/network-config-analyzer/NetworkConfigQuery.py
@@ -233,7 +233,7 @@ class RedundancyQuery(NetworkConfigQuery):
 
         if res > 0:
             output_explanation = '\n'.join(redundancies)
-            return QueryAnswer(True, 'Redundancies found in ' + self.config.name, output_explanation, res)
+            return QueryAnswer(True, 'Redundancies found in ' + self.config.name + '\n', output_explanation, res)
         return QueryAnswer(False, 'No redundancy found in ' + self.config.name)
 
     def compute_query_output(self, query_answer):

--- a/network-config-analyzer/NetworkConfigQuery.py
+++ b/network-config-analyzer/NetworkConfigQuery.py
@@ -1198,10 +1198,10 @@ class ForbidsQuery(TwoNetworkConfigsQuery):
     def compute_query_output(self, query_answer, cmd_line_flag=False):
         res = not query_answer.numerical_result if cmd_line_flag else query_answer.bool_result
         query_output = query_answer.output_result + '\n'
-        if query_answer.bool_result and query_answer.numerical_result == 0:
+        if query_answer.bool_result:
             query_output += f'{self.config2.name} does not forbid connections specified in {self.config1.name}: ' \
                 f'{query_answer.output_explanation}'
-        else:
+        elif query_answer.numerical_result == 1:
             query_output += f'{self.config2.name} forbids connections specified in {self.config1.name}'
         return res, query_output
 

--- a/network-config-analyzer/NetworkConfigQuery.py
+++ b/network-config-analyzer/NetworkConfigQuery.py
@@ -1200,7 +1200,7 @@ class ForbidsQuery(TwoNetworkConfigsQuery):
         query_output = query_answer.output_result + '\n'
         if query_answer.numerical_result == 0:
             query_output += f'{self.config2.name} does not forbid connections specified in {self.config1.name}:' \
-                           f'{query_answer.output_explanation}'
+                        f'{query_answer.output_explanation}'
         else:
             query_output += f'{self.config2.name} forbids connections specified in {self.config1.name}'
         return res, query_output

--- a/network-config-analyzer/NetworkConfigQuery.py
+++ b/network-config-analyzer/NetworkConfigQuery.py
@@ -1198,7 +1198,7 @@ class ForbidsQuery(TwoNetworkConfigsQuery):
     def compute_query_output(self, query_answer, cmd_line_flag=False):
         res = not query_answer.numerical_result if cmd_line_flag else query_answer.bool_result
         query_output = query_answer.output_result + '\n'
-        if query_answer.numerical_result == 0:
+        if query_answer.bool_result and query_answer.numerical_result == 0:
             query_output += f'{self.config2.name} does not forbid connections specified in {self.config1.name}: ' \
                 f'{query_answer.output_explanation}'
         else:

--- a/network-config-analyzer/NetworkConfigQuery.py
+++ b/network-config-analyzer/NetworkConfigQuery.py
@@ -1199,7 +1199,7 @@ class ForbidsQuery(TwoNetworkConfigsQuery):
         res = not query_answer.numerical_result if cmd_line_flag else query_answer.bool_result
         query_output = query_answer.output_result + '\n'
         if query_answer.numerical_result == 0:
-            query_output += f'{self.config2.name} does not forbid connections specified in {self.config1.name}:' \
+            query_output += f'{self.config2.name} does not forbid connections specified in {self.config1.name}: ' \
                         f'{query_answer.output_explanation}'
         else:
             query_output += f'{self.config2.name} forbids connections specified in {self.config1.name}'

--- a/tests/k8s_cmdline_tests.yaml
+++ b/tests/k8s_cmdline_tests.yaml
@@ -68,6 +68,14 @@
     --pod_list k8s_testcases/example_podlist/pods_list.json
   expected: 1
 
+- name: two_way_containment_policies
+  args: >
+    --equiv k8s_testcases/example_policies/testcase1/testcase1-networkpolicy1.yaml
+    --base_np_list k8s_testcases/example_policies/testcase1/testcase1-networkpolicy2.yaml
+    --ns_list k8s_testcases/example_podlist/ns_list.json
+    --pod_list k8s_testcases/example_podlist/pods_list.json
+  expected: 0
+
 - name: basic_semantic_diff
   args: >
     --semantic_diff k8s_testcases/example_policies/testcase7/testcase7-networkpolicy1.yaml


### PR DESCRIPTION
I went through all "compute_query_output" and "exec" methods for all queries to make sure that the output is computed as expected (as described in the docs). 
For some queries, the behavior was as expected but minor fixes were done to print the full output results.
Forbids indeed didn't behave as expected for all cases, fixed 