### PR TITLE
global workflow permissions + action hashes instead of versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,11 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ master ]
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze
@@ -22,13 +27,10 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'python' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -39,22 +41,6 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/make-github-and-docker-release.yml
+++ b/.github/workflows/make-github-and-docker-release.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: 0.0.0
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   push_to_registry:
     name: Push a Docker image to the Docker Hub and create a github release
@@ -18,17 +22,17 @@ jobs:
           echo "Creating docker image and github release of the NCA version ${{ github.event.inputs.version }}"
 
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
           push: true
@@ -41,7 +45,7 @@ jobs:
           git push origin v${{ github.event.inputs.version }}
 
       - name: Create a github release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/make-github-and-docker-release.yml
+++ b/.github/workflows/make-github-and-docker-release.yml
@@ -9,7 +9,7 @@ on:
         default: 0.0.0
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:

--- a/.github/workflows/reset-tests-expected-runtime.yml
+++ b/.github/workflows/reset-tests-expected-runtime.yml
@@ -1,23 +1,31 @@
 name: reset-tests-expected-runtime
+
 on:
   workflow_dispatch: # manual triggering
+
+permissions:
+  actions: read
+  contents: write
+
 jobs:
   reset_all_tests_runtime:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: ./.github/actions/setup-nca-env
-      - uses: dawidd6/action-download-artifact@v2
+      - uses: dawidd6/action-download-artifact@575b1e4167df67acf7e692af784566618b23c71e
         with:
           workflow: test-push.yml
           workflow_conclusion: success
           name: run-alltests-log
           path: tests/
       - name: run script to update expected run time for all tests
-        run: python tests/update_expected_runtime.py --changed_tests ALL_TESTS
-      - run: rm tests/run_log.txt
+        run: |
+          python tests/update_expected_runtime.py --changed_tests ALL_TESTS
+          rm tests/run_log.txt
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          default_author: github_actions
-          message: 'Updating the tests_expected_runtime.csv file'
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email '${{ github.actor }}@users.noreply.github.com'
+          git add tests/tests_expected_runtime.csv
+          git diff-index --quiet HEAD || ( git commit -m"Updating expected-runtimes file" && git push )

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -7,13 +7,17 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   test-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         id: build_docker
         with:
           context: .
@@ -23,7 +27,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: ./.github/actions/setup-nca-env
       - run: pip install flake8
       - name: Lint with flake8
@@ -32,24 +36,24 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: ./.github/actions/setup-nca-env
       - run: python tests/run_unittests.py
   all-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: ./.github/actions/setup-nca-env
       - name: Run all tests
         env:
           GHE_TOKEN: ${{ github.token }}
         run: python tests/run_all_tests.py --type=general --check_run_time | tee tests/run_log.txt
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
         with:
           name: run-alltests-log
           path: tests/run_log.txt
       - name: Upload failed run-time tests file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
         with:
           name: failed-run-time-check-file
           path: ./tests/tests_failed_runtime_check.csv
@@ -57,13 +61,13 @@ jobs:
   fw-rules-assertion-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: ./.github/actions/setup-nca-env
       - run:  python tests/run_all_tests.py --type=fw_rules_assertions
   live-cluster:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: ./.github/actions/setup-nca-env
-      - uses: helm/kind-action@v1.2.0
+      - uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478
       - run:  python tests/run_all_tests.py --type=k8s_live_general

--- a/.github/workflows/update-tests-expected-output.yml
+++ b/.github/workflows/update-tests-expected-output.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: ./.github/actions/setup-nca-env
       - name: update or add expected output files
         run:  python tests/run_all_tests.py --type=general --override_expected_output_files --create_expected_output_files
+        env:
+          GHE_TOKEN: ${{ github.token }}
       - name: Commit changes
         run: |
           git config user.name ${{ github.actor }}

--- a/.github/workflows/update-tests-expected-output.yml
+++ b/.github/workflows/update-tests-expected-output.yml
@@ -3,17 +3,22 @@ name: update-tests-expected-output
 on:
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: ./.github/actions/setup-nca-env
       - name: update or add expected output files
         run:  python tests/run_all_tests.py --type=general --override_expected_output_files --create_expected_output_files
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          default_author: github_actions
-          message: 'Updating and Adding tests expected output files'
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email '${{ github.actor }}@users.noreply.github.com'
+          git add tests
+          git diff-index --quiet HEAD || ( git commit -m"Updating and Adding tests expected output files" && git push )
 

--- a/.github/workflows/update-tests-expected-runtime.yml
+++ b/.github/workflows/update-tests-expected-runtime.yml
@@ -1,17 +1,19 @@
 name: update-tests-expected-runtime
+
 on:
   workflow_dispatch: # manual triggering
-#  workflow_run:
-#    workflows: [test-push]
-#    types:
-#      - completed
+
+permissions:
+  actions: read
+  contents: write
+
 jobs:
   changed-tests:
     runs-on: ubuntu-latest
     outputs:
       changed_tests: ${{ steps.changes.outputs.changed_tests}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-nca-env
@@ -24,19 +26,21 @@ jobs:
     needs: changed-tests
     if: ${{needs.changed-tests.outputs.changed_tests}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: ./.github/actions/setup-nca-env
-      - uses: dawidd6/action-download-artifact@v2
+      - uses: dawidd6/action-download-artifact@575b1e4167df67acf7e692af784566618b23c71e
         with:
           workflow: test-push.yml
           workflow_conclusion: success
           name: run-alltests-log
           path: tests/
       - name: run script to update expected run time
-        run: python tests/update_expected_runtime.py --changed_tests ${{needs.changed-tests.outputs.changed_tests}}
-      - run: rm tests/run_log.txt
+        run: |
+          python tests/update_expected_runtime.py --changed_tests ${{needs.changed-tests.outputs.changed_tests}}
+          rm tests/run_log.txt
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          default_author: github_actions
-          message: 'Updating the tests_expected_runtime.csv file'
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email '${{ github.actor }}@users.noreply.github.com'
+          git add tests/tests_expected_runtime.csv
+          git diff-index --quiet HEAD || ( git commit -m"Updating expected-runtimes file" && git push )


### PR DESCRIPTION
Also, avoid using EndBug's add-and-commit 3rd-party action

Fixes #191 
