### PR TITLE
More permissions and hashes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,12 +16,13 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/make-github-and-docker-release.yml
+++ b/.github/workflows/make-github-and-docker-release.yml
@@ -9,13 +9,15 @@ on:
         default: 0.0.0
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   push_to_registry:
     name: Push a Docker image to the Docker Hub and create a github release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Print the version number
         run: |

--- a/.github/workflows/reset-tests-expected-runtime.yml
+++ b/.github/workflows/reset-tests-expected-runtime.yml
@@ -5,11 +5,13 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 jobs:
   reset_all_tests_runtime:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: ./.github/actions/setup-nca-env

--- a/.github/workflows/update-tests-expected-output.yml
+++ b/.github/workflows/update-tests-expected-output.yml
@@ -5,11 +5,13 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: ./.github/actions/setup-nca-env

--- a/.github/workflows/update-tests-expected-runtime.yml
+++ b/.github/workflows/update-tests-expected-runtime.yml
@@ -5,7 +5,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 jobs:
   changed-tests:
@@ -23,6 +23,8 @@ jobs:
           echo "::set-output name=changed_tests::$(((git fetch origin master:master) && (git diff --name-only --diff-filter=AMRD master)) | grep -E '*-scheme\.yaml|k8s_cmdline_tests.yaml' | xargs)"
   update-tests-runtime:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: changed-tests
     if: ${{needs.changed-tests.outputs.changed_tests}}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache2.0
 #
 
-FROM python:3.8-slim
+# Using python:3.8-slim
+FROM python@sha256:d82f9b8300f1ab29b3a940b1a2dcf4590db5213ed1053ea49b44898367d38cf3
 
 RUN python -m pip install -U pip wheel setuptools
 COPY requirements.txt /nca/


### PR DESCRIPTION
openssf-scorecard wants write permission to be defined per-job, and not globally per-workflow.
Also, a hash for base docker image