### PR TITLE
fix connectivity map disjoint ip blocks issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.dot   diff=
+*.DOT   diff=

--- a/network-config-analyzer/IstioPolicyYamlParser.py
+++ b/network-config-analyzer/IstioPolicyYamlParser.py
@@ -35,7 +35,7 @@ class IstioPolicyYamlParser(GenericYamlParser):
         self.policy = policy
         self.peer_container = peer_container
         self.namespace = None
-        self.allowed_labels = set()
+        self.referenced_labels = set()
 
     def parse_label_selector(self, label_selector):
         """
@@ -57,7 +57,7 @@ class IstioPolicyYamlParser(GenericYamlParser):
         if match_labels:
             for key, val in match_labels.items():
                 res &= self.peer_container.get_peers_with_label(key, [val])
-            self.allowed_labels.add(':'.join(match_labels.keys()))
+            self.referenced_labels.add(':'.join(match_labels.keys()))
 
         if not res:
             self.warning('A podSelector selects no pods. Better use "podSelector: Null"', label_selector)
@@ -629,5 +629,6 @@ class IstioPolicyYamlParser(GenericYamlParser):
             self.syntax_error("DENY action without rules is meaningless as it will never be triggered")
 
         res_policy.findings = self.warning_msgs
+        res_policy.referenced_labels = self.referenced_labels
 
         return res_policy

--- a/network-config-analyzer/K8sPolicyYamlParser.py
+++ b/network-config-analyzer/K8sPolicyYamlParser.py
@@ -28,7 +28,7 @@ class K8sPolicyYamlParser(GenericYamlParser):
         self.policy = policy
         self.peer_container = peer_container
         self.namespace = None
-        self.allowed_labels = set()
+        self.referenced_labels = set()
 
     def check_dns_subdomain_name(self, value, key_container):
         """
@@ -169,7 +169,7 @@ class K8sPolicyYamlParser(GenericYamlParser):
                 else:
                     res &= self.peer_container.get_peers_with_label(key, [val])
                 keys_set.add(key)
-            self.allowed_labels.add(':'.join(keys_set))
+            self.referenced_labels.add(':'.join(keys_set))
 
         match_expressions = label_selector.get('matchExpressions')
         if match_expressions:
@@ -178,7 +178,7 @@ class K8sPolicyYamlParser(GenericYamlParser):
                 res &= self.parse_label_selector_requirement(requirement, namespace_selector)
                 key = requirement['key']
                 keys_set.add(key)
-            self.allowed_labels.add(':'.join(keys_set))
+            self.referenced_labels.add(':'.join(keys_set))
 
         if not res:
             if namespace_selector:
@@ -440,4 +440,5 @@ class K8sPolicyYamlParser(GenericYamlParser):
                 res_policy.add_egress_rule(self.parse_egress_rule(egress_rule))
 
         res_policy.findings = self.warning_msgs
+        res_policy.referenced_labels = self.referenced_labels
         return res_policy

--- a/network-config-analyzer/NetworkConfig.py
+++ b/network-config-analyzer/NetworkConfig.py
@@ -128,6 +128,8 @@ class NetworkConfig:
         self.policies[policy.full_name()] = policy
         insort(self.sorted_policies, policy)
 
+        self.allowed_labels |= policy.referenced_labels
+
     def add_exclusive_policy_given_profiles(self, policy, profiles):
         self.profiles = profiles
         self.add_policy(policy)
@@ -147,15 +149,12 @@ class NetworkConfig:
             elif policy_type == NetworkPolicy.PolicyType.K8sNetworkPolicy:
                 parsed_element = K8sPolicyYamlParser(policy, self.peer_container, file_name)
                 self.add_policy(parsed_element.parse_policy())
-                self.allowed_labels |= parsed_element.allowed_labels
             elif policy_type == NetworkPolicy.PolicyType.IstioAuthorizationPolicy:
                 parsed_element = IstioPolicyYamlParser(policy, self.peer_container, file_name)
                 self.add_policy(parsed_element.parse_policy())
-                self.allowed_labels |= parsed_element.allowed_labels
             else:
                 parsed_element = CalicoPolicyYamlParser(policy, self.peer_container, file_name)
                 self.add_policy(parsed_element.parse_policy())
-                self.allowed_labels |= parsed_element.allowed_labels
 
     def _add_policy_to_parse_queue(self, policy_object, file_name):
         policy_type = NetworkPolicy.get_policy_type(policy_object)

--- a/network-config-analyzer/NetworkConfigQuery.py
+++ b/network-config-analyzer/NetworkConfigQuery.py
@@ -1037,10 +1037,10 @@ class PermitsQuery(TwoNetworkConfigsQuery):
                 query_output = query_answer.output_result
             else:
                 res = 1
-                query_output = self.config2.name + ' does not permit connections specified in ' + \
-                               self.config1.name + ':' + query_answer.output_explanation
+                query_output = f'{self.config2.name} does not permit connections specified in {self.config1.name}:'
+                query_output += query_answer.output_explanation
         else:
-            query_output = self.config2.name + ' permits all connections specified in ' + self.config1.name
+            query_output = f'{self.config2.name} permits all connections specified in {self.config1.name}'
         if cmd_line_flag:
             res = not query_answer.bool_result
         return res, query_output

--- a/network-config-analyzer/NetworkPolicy.py
+++ b/network-config-analyzer/NetworkPolicy.py
@@ -35,6 +35,7 @@ class NetworkPolicy:
         self.affects_ingress = False  # whether the policy affects the ingress of the selected peers
         self.affects_egress = False  # whether the policy affects the egress of the selected peers
         self.findings = []  # accumulated findings which are relevant only to this policy (emptiness and redundancy)
+        self.referenced_labels = set()
 
     def __str__(self):
         return self.full_name()

--- a/tests/calico_testcases/example_policies/testcase16-nets/expected_output/testcase16-scheme_output.txt
+++ b/tests/calico_testcases/example_policies/testcase16-nets/expected_output/testcase16-scheme_output.txt
@@ -1,0 +1,5 @@
+final fw rules for query: connectivity_map_testcase16, config: equiv-ranges-containment-games/kube-system/testcase16-nets-almost-all-range-smaller:
+src ip block: 0.0.0.0/0 dst_ns: [kube-system] dst_pods: [has(tier)] conn: All connections
+src ip block: ::/0 dst_ns: [kube-system] dst_pods: [has(tier)] conn: All connections
+src_ns: [kube-system] src_pods: [has(tier)] dst ip block: 64.0.0.0-255.255.255.255 conn: TCP
+

--- a/tests/calico_testcases/example_policies/testcase16-nets/testcase16-scheme.yaml
+++ b/tests/calico_testcases/example_policies/testcase16-nets/testcase16-scheme.yaml
@@ -106,3 +106,9 @@ queries:
       - equiv-ranges-containment-games/kube-system/testcase16-simple-all-range
       - equiv-ranges-containment-games/kube-system/testcase16-Allow-ingress-All-egress-TCP
     expected: 0
+
+# connectivity map test (requires disjoint ip blocks)
+  - name: connectivity_map_testcase16
+    connectivityMap:
+      - equiv-ranges-containment-games/kube-system/testcase16-nets-almost-all-range-smaller
+    expectedOutput: expected_output/testcase16-scheme_output.txt

--- a/tests/fw_rules_tests/policies/expected_output/calico-testcase15-scheme_output.txt
+++ b/tests/fw_rules_tests/policies/expected_output/calico-testcase15-scheme_output.txt
@@ -1,3 +1,3 @@
 final fw rules for query: connectivity_map_1, config: ports-rectangles/kube-system/testcase15-named-ports-rectangles-base-2-equiv:
-src_ns: [kube-system] src_pods: [*] dst_ns: [kube-system] dst_pods: [kube-dns-amd64-d66bf76db] conn: UDP {'src_ports': '80-100', 'dst_ports': '1-10052,10054-65535'}
+src_ns: [kube-system] src_pods: [*] dst_ns: [kube-system] dst_pods: [has(has_named_port)] conn: UDP {'src_ports': '80-100', 'dst_ports': '1-10052,10054-65535'}
 

--- a/tests/fw_rules_tests/policies/expected_output/calico-testcase15-scheme_output.yaml
+++ b/tests/fw_rules_tests/policies/expected_output/calico-testcase15-scheme_output.yaml
@@ -7,7 +7,7 @@
     dst_ns:
     - kube-system
     dst_pods:
-    - kube-dns-amd64-d66bf76db
+    - has(has_named_port)
     connection:
     - Protocol: UDP
       properties:

--- a/tests/fw_rules_tests/policies/expected_output/calico-testcase20-Eran_gnps_query_output.txt
+++ b/tests/fw_rules_tests/policies/expected_output/calico-testcase20-Eran_gnps_query_output.txt
@@ -1,65 +1,124 @@
 final fw rules for query: Eran_gnps, config: Eran_gnps:
-src ip block: 0.0.0.0/0 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
+src ip block: 0.0.0.0-5.10.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 0.0.0.0/0 dst_ns: [kube-system] dst_pods: [*] conn: All connections
 src ip block: 119.81.136.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 119.81.137.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 119.81.138.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 119.81.140.0-130.198.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 130.198.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 130.198.120.0-158.85.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 158.85.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 158.85.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 158.85.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 158.85.120.0-159.8.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 159.122.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 159.122.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 159.122.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 159.122.120.0-159.122.135.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 159.122.136.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 159.122.137.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 159.122.138.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 159.122.140.0-159.253.155.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 159.253.156.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 159.253.157.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 159.253.158.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 159.253.160.0-161.202.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 159.8.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 159.8.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 159.8.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 159.8.120.0-159.8.195.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 159.8.196.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 159.8.197.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 159.8.198.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 159.8.200.0-159.122.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 161.202.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 161.202.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 161.202.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 161.202.120.0-168.1.15.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 168.1.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 168.1.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 168.1.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 168.1.120.0-169.38.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 168.1.16.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 168.1.17.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 168.1.18.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 168.1.20.0-168.1.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.38.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.38.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.38.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.38.120.0-169.45.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.45.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.45.120.0-169.46.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.46.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.46.120.0-169.47.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.47.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.47.120.0-169.48.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.48.118.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.48.119.0-169.51.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.51.118.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.51.119.0-169.54.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.54.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.54.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.54.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.54.120.0-169.55.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.55.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.55.120.0-169.56.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.56.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.56.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.56.118.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.56.119.0-169.57.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.57.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.57.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.57.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.57.120.0-169.57.135.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.57.136.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.57.137.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.57.138.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.57.140.0-169.60.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.60.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.60.120.0-169.61.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 169.61.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 169.61.120.0-173.192.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 173.192.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 173.192.120.0-173.193.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 173.193.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 173.193.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 173.193.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 173.193.120.0-174.133.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 174.133.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 174.133.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 174.133.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 174.133.120.0-184.172.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 184.172.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 184.172.120.0-192.255.17.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 192.255.18.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 192.255.19.0-192.255.37.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 192.255.38.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 192.255.39.0-198.23.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 198.23.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 198.23.120.0-208.43.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 208.43.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 208.43.120.0-255.255.255.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 5.10.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 5.10.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 5.10.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 5.10.120.0-50.22.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 50.22.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 50.22.120.0-50.22.254.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 50.22.255.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 50.23.0.0-50.23.115.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 50.23.116.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 50.23.117.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 50.23.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 50.23.120.0-50.23.166.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 50.23.167.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 50.23.168.0-66.228.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 66.228.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 66.228.120.0-67.228.117.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 67.228.118.0/23 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 67.228.120.0-75.126.60.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: 75.126.61.0/24 dst_ns: [None] dst_pods: [has(vendor.role)] conn: All connections
+src ip block: 75.126.62.0-119.81.135.255 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: ::/0 dst_ns: [None] dst_pods: [has(vendor.role)] conn: ICMP,TCP 52311,UDP 52311,protocols numbers: 112
 src ip block: ::/0 dst_ns: [kube-system] dst_pods: [*] conn: All connections
 src_ns: [None] src_pods: [has(vendor.role)] dst ip block: 0.0.0.0/0 conn: All connections

--- a/tests/fw_rules_tests/policies/expected_output/calico-testcase20-Eran_gnps_query_output.yaml
+++ b/tests/fw_rules_tests/policies/expected_output/calico-testcase20-Eran_gnps_query_output.yaml
@@ -1,7 +1,1309 @@
 - query: 'Eran_gnps_yaml, config: Eran_gnps'
   rules:
   - src_ip_block:
-    - 0.0.0.0/0
+    - 0.0.0.0/6
+    - 4.0.0.0/8
+    - 5.0.0.0/13
+    - 5.10.0.0/18
+    - 5.10.112.0/22
+    - 5.10.64.0/19
+    - 5.10.96.0/20
+    - 5.8.0.0/15
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 119.81.137.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 119.128.0.0/9
+    - 119.81.140.0/22
+    - 119.81.144.0/20
+    - 119.81.160.0/19
+    - 119.81.192.0/18
+    - 119.82.0.0/15
+    - 119.84.0.0/14
+    - 119.88.0.0/13
+    - 119.96.0.0/11
+    - 120.0.0.0/5
+    - 128.0.0.0/7
+    - 130.0.0.0/9
+    - 130.128.0.0/10
+    - 130.192.0.0/14
+    - 130.196.0.0/15
+    - 130.198.0.0/18
+    - 130.198.112.0/22
+    - 130.198.116.0/23
+    - 130.198.64.0/19
+    - 130.198.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 130.198.120.0/21
+    - 130.198.128.0/17
+    - 130.199.0.0/16
+    - 130.200.0.0/13
+    - 130.208.0.0/12
+    - 130.224.0.0/11
+    - 131.0.0.0/8
+    - 132.0.0.0/6
+    - 136.0.0.0/5
+    - 144.0.0.0/5
+    - 152.0.0.0/6
+    - 156.0.0.0/7
+    - 158.0.0.0/10
+    - 158.64.0.0/12
+    - 158.80.0.0/14
+    - 158.84.0.0/16
+    - 158.85.0.0/18
+    - 158.85.112.0/22
+    - 158.85.64.0/19
+    - 158.85.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 158.85.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 158.128.0.0/9
+    - 158.85.120.0/21
+    - 158.85.128.0/17
+    - 158.86.0.0/15
+    - 158.88.0.0/13
+    - 158.96.0.0/11
+    - 159.0.0.0/13
+    - 159.8.0.0/18
+    - 159.8.112.0/22
+    - 159.8.64.0/19
+    - 159.8.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 159.122.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 159.122.120.0/21
+    - 159.122.128.0/21
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 159.122.137.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 159.122.140.0/22
+    - 159.122.144.0/20
+    - 159.122.160.0/19
+    - 159.122.192.0/18
+    - 159.123.0.0/16
+    - 159.124.0.0/14
+    - 159.128.0.0/10
+    - 159.192.0.0/11
+    - 159.224.0.0/12
+    - 159.240.0.0/13
+    - 159.248.0.0/14
+    - 159.252.0.0/16
+    - 159.253.0.0/17
+    - 159.253.128.0/20
+    - 159.253.144.0/21
+    - 159.253.152.0/22
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 159.253.157.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 159.253.160.0/19
+    - 159.253.192.0/18
+    - 159.254.0.0/15
+    - 160.0.0.0/8
+    - 161.0.0.0/9
+    - 161.128.0.0/10
+    - 161.192.0.0/13
+    - 161.200.0.0/15
+    - 161.202.0.0/18
+    - 161.202.112.0/22
+    - 161.202.64.0/19
+    - 161.202.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 159.8.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 159.8.120.0/21
+    - 159.8.128.0/18
+    - 159.8.192.0/22
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 159.8.197.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 159.10.0.0/15
+    - 159.112.0.0/13
+    - 159.12.0.0/14
+    - 159.120.0.0/15
+    - 159.122.0.0/18
+    - 159.122.112.0/22
+    - 159.122.64.0/19
+    - 159.122.96.0/20
+    - 159.16.0.0/12
+    - 159.32.0.0/11
+    - 159.64.0.0/11
+    - 159.8.200.0/21
+    - 159.8.208.0/20
+    - 159.8.224.0/19
+    - 159.9.0.0/16
+    - 159.96.0.0/12
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 161.202.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 161.202.120.0/21
+    - 161.202.128.0/17
+    - 161.203.0.0/16
+    - 161.204.0.0/14
+    - 161.208.0.0/12
+    - 161.224.0.0/11
+    - 162.0.0.0/7
+    - 164.0.0.0/6
+    - 168.0.0.0/16
+    - 168.1.0.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 168.1.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 168.1.120.0/21
+    - 168.1.128.0/17
+    - 168.128.0.0/9
+    - 168.16.0.0/12
+    - 168.2.0.0/15
+    - 168.32.0.0/11
+    - 168.4.0.0/14
+    - 168.64.0.0/10
+    - 168.8.0.0/13
+    - 169.0.0.0/11
+    - 169.32.0.0/14
+    - 169.36.0.0/15
+    - 169.38.0.0/18
+    - 169.38.112.0/22
+    - 169.38.64.0/19
+    - 169.38.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 168.1.17.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 168.1.112.0/22
+    - 168.1.20.0/22
+    - 168.1.24.0/21
+    - 168.1.32.0/19
+    - 168.1.64.0/19
+    - 168.1.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.38.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.38.120.0/21
+    - 169.38.128.0/17
+    - 169.39.0.0/16
+    - 169.40.0.0/14
+    - 169.44.0.0/16
+    - 169.45.0.0/18
+    - 169.45.112.0/22
+    - 169.45.116.0/23
+    - 169.45.64.0/19
+    - 169.45.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.45.120.0/21
+    - 169.45.128.0/17
+    - 169.46.0.0/18
+    - 169.46.112.0/22
+    - 169.46.116.0/23
+    - 169.46.64.0/19
+    - 169.46.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.46.120.0/21
+    - 169.46.128.0/17
+    - 169.47.0.0/18
+    - 169.47.112.0/22
+    - 169.47.116.0/23
+    - 169.47.64.0/19
+    - 169.47.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.47.120.0/21
+    - 169.47.128.0/17
+    - 169.48.0.0/18
+    - 169.48.112.0/22
+    - 169.48.116.0/23
+    - 169.48.64.0/19
+    - 169.48.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.48.119.0/24
+    - 169.48.120.0/21
+    - 169.48.128.0/17
+    - 169.49.0.0/16
+    - 169.50.0.0/16
+    - 169.51.0.0/18
+    - 169.51.112.0/22
+    - 169.51.116.0/23
+    - 169.51.64.0/19
+    - 169.51.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.51.119.0/24
+    - 169.51.120.0/21
+    - 169.51.128.0/17
+    - 169.52.0.0/15
+    - 169.54.0.0/18
+    - 169.54.112.0/22
+    - 169.54.64.0/19
+    - 169.54.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.54.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.54.120.0/21
+    - 169.54.128.0/17
+    - 169.55.0.0/18
+    - 169.55.112.0/22
+    - 169.55.116.0/23
+    - 169.55.64.0/19
+    - 169.55.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.55.120.0/21
+    - 169.55.128.0/17
+    - 169.56.0.0/18
+    - 169.56.112.0/22
+    - 169.56.64.0/19
+    - 169.56.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.56.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.56.119.0/24
+    - 169.56.120.0/21
+    - 169.56.128.0/17
+    - 169.57.0.0/18
+    - 169.57.112.0/22
+    - 169.57.64.0/19
+    - 169.57.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.57.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.57.120.0/21
+    - 169.57.128.0/21
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.57.137.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.57.140.0/22
+    - 169.57.144.0/20
+    - 169.57.160.0/19
+    - 169.57.192.0/18
+    - 169.58.0.0/15
+    - 169.60.0.0/18
+    - 169.60.112.0/22
+    - 169.60.116.0/23
+    - 169.60.64.0/19
+    - 169.60.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.60.120.0/21
+    - 169.60.128.0/17
+    - 169.61.0.0/18
+    - 169.61.112.0/22
+    - 169.61.116.0/23
+    - 169.61.64.0/19
+    - 169.61.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 169.128.0.0/9
+    - 169.61.120.0/21
+    - 169.61.128.0/17
+    - 169.62.0.0/15
+    - 169.64.0.0/10
+    - 170.0.0.0/7
+    - 172.0.0.0/8
+    - 173.0.0.0/9
+    - 173.128.0.0/10
+    - 173.192.0.0/18
+    - 173.192.112.0/22
+    - 173.192.116.0/23
+    - 173.192.64.0/19
+    - 173.192.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 173.192.120.0/21
+    - 173.192.128.0/17
+    - 173.193.0.0/18
+    - 173.193.112.0/22
+    - 173.193.64.0/19
+    - 173.193.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 173.193.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 173.193.120.0/21
+    - 173.193.128.0/17
+    - 173.194.0.0/15
+    - 173.196.0.0/14
+    - 173.200.0.0/13
+    - 173.208.0.0/12
+    - 173.224.0.0/11
+    - 174.0.0.0/9
+    - 174.128.0.0/14
+    - 174.132.0.0/16
+    - 174.133.0.0/18
+    - 174.133.112.0/22
+    - 174.133.64.0/19
+    - 174.133.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 174.133.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 174.133.120.0/21
+    - 174.133.128.0/17
+    - 174.134.0.0/15
+    - 174.136.0.0/13
+    - 174.144.0.0/12
+    - 174.160.0.0/11
+    - 174.192.0.0/10
+    - 175.0.0.0/8
+    - 176.0.0.0/5
+    - 184.0.0.0/9
+    - 184.128.0.0/11
+    - 184.160.0.0/13
+    - 184.168.0.0/14
+    - 184.172.0.0/18
+    - 184.172.112.0/22
+    - 184.172.116.0/23
+    - 184.172.64.0/19
+    - 184.172.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 184.172.120.0/21
+    - 184.172.128.0/17
+    - 184.173.0.0/16
+    - 184.174.0.0/15
+    - 184.176.0.0/12
+    - 184.192.0.0/10
+    - 185.0.0.0/8
+    - 186.0.0.0/7
+    - 188.0.0.0/6
+    - 192.0.0.0/9
+    - 192.128.0.0/10
+    - 192.192.0.0/11
+    - 192.224.0.0/12
+    - 192.240.0.0/13
+    - 192.248.0.0/14
+    - 192.252.0.0/15
+    - 192.254.0.0/16
+    - 192.255.0.0/20
+    - 192.255.16.0/23
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 192.255.19.0/24
+    - 192.255.20.0/22
+    - 192.255.24.0/21
+    - 192.255.32.0/22
+    - 192.255.36.0/23
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 192.255.128.0/17
+    - 192.255.39.0/24
+    - 192.255.40.0/21
+    - 192.255.48.0/20
+    - 192.255.64.0/18
+    - 193.0.0.0/8
+    - 194.0.0.0/7
+    - 196.0.0.0/7
+    - 198.0.0.0/12
+    - 198.16.0.0/14
+    - 198.20.0.0/15
+    - 198.22.0.0/16
+    - 198.23.0.0/18
+    - 198.23.112.0/22
+    - 198.23.116.0/23
+    - 198.23.64.0/19
+    - 198.23.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 198.128.0.0/9
+    - 198.23.120.0/21
+    - 198.23.128.0/17
+    - 198.24.0.0/13
+    - 198.32.0.0/11
+    - 198.64.0.0/10
+    - 199.0.0.0/8
+    - 200.0.0.0/5
+    - 208.0.0.0/11
+    - 208.32.0.0/13
+    - 208.40.0.0/15
+    - 208.42.0.0/16
+    - 208.43.0.0/18
+    - 208.43.112.0/22
+    - 208.43.116.0/23
+    - 208.43.64.0/19
+    - 208.43.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 208.128.0.0/9
+    - 208.43.120.0/21
+    - 208.43.128.0/17
+    - 208.44.0.0/14
+    - 208.48.0.0/12
+    - 208.64.0.0/10
+    - 209.0.0.0/8
+    - 210.0.0.0/7
+    - 212.0.0.0/6
+    - 216.0.0.0/5
+    - 224.0.0.0/3
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 5.10.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 16.0.0.0/4
+    - 32.0.0.0/4
+    - 48.0.0.0/7
+    - 5.10.120.0/21
+    - 5.10.128.0/17
+    - 5.11.0.0/16
+    - 5.12.0.0/14
+    - 5.128.0.0/9
+    - 5.16.0.0/12
+    - 5.32.0.0/11
+    - 5.64.0.0/10
+    - 50.0.0.0/12
+    - 50.16.0.0/14
+    - 50.20.0.0/15
+    - 50.22.0.0/18
+    - 50.22.112.0/22
+    - 50.22.116.0/23
+    - 50.22.64.0/19
+    - 50.22.96.0/20
+    - 6.0.0.0/7
+    - 8.0.0.0/5
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 50.22.120.0/21
+    - 50.22.128.0/18
+    - 50.22.192.0/19
+    - 50.22.224.0/20
+    - 50.22.240.0/21
+    - 50.22.248.0/22
+    - 50.22.252.0/23
+    - 50.22.254.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 50.23.0.0/18
+    - 50.23.112.0/22
+    - 50.23.64.0/19
+    - 50.23.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 50.23.117.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 50.23.120.0/21
+    - 50.23.128.0/19
+    - 50.23.160.0/22
+    - 50.23.164.0/23
+    - 50.23.166.0/24
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 50.128.0.0/9
+    - 50.23.168.0/21
+    - 50.23.176.0/20
+    - 50.23.192.0/18
+    - 50.24.0.0/13
+    - 50.32.0.0/11
+    - 50.64.0.0/10
+    - 51.0.0.0/8
+    - 52.0.0.0/6
+    - 56.0.0.0/5
+    - 64.0.0.0/7
+    - 66.0.0.0/9
+    - 66.128.0.0/10
+    - 66.192.0.0/11
+    - 66.224.0.0/14
+    - 66.228.0.0/18
+    - 66.228.112.0/22
+    - 66.228.116.0/23
+    - 66.228.64.0/19
+    - 66.228.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 66.228.120.0/21
+    - 66.228.128.0/17
+    - 66.229.0.0/16
+    - 66.230.0.0/15
+    - 66.232.0.0/13
+    - 66.240.0.0/12
+    - 67.0.0.0/9
+    - 67.128.0.0/10
+    - 67.192.0.0/11
+    - 67.224.0.0/14
+    - 67.228.0.0/18
+    - 67.228.112.0/22
+    - 67.228.116.0/23
+    - 67.228.64.0/19
+    - 67.228.96.0/20
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 67.228.120.0/21
+    - 67.228.128.0/17
+    - 67.229.0.0/16
+    - 67.230.0.0/15
+    - 67.232.0.0/13
+    - 67.240.0.0/12
+    - 68.0.0.0/6
+    - 72.0.0.0/7
+    - 74.0.0.0/8
+    - 75.0.0.0/10
+    - 75.112.0.0/13
+    - 75.120.0.0/14
+    - 75.124.0.0/15
+    - 75.126.0.0/19
+    - 75.126.32.0/20
+    - 75.126.48.0/21
+    - 75.126.56.0/22
+    - 75.126.60.0/24
+    - 75.64.0.0/11
+    - 75.96.0.0/12
+    dst_ns:
+    - None
+    dst_pods:
+    - has(vendor.role)
+    connection:
+    - Protocol: ICMP
+    - Protocol: TCP
+      Ports:
+      - 52311
+    - Protocol: UDP
+      Ports:
+      - 52311
+    - Protocol: 112
+  - src_ip_block:
+    - 112.0.0.0/6
+    - 116.0.0.0/7
+    - 118.0.0.0/8
+    - 119.0.0.0/10
+    - 119.64.0.0/12
+    - 119.80.0.0/16
+    - 119.81.0.0/17
+    - 119.81.128.0/21
+    - 75.126.128.0/17
+    - 75.126.62.0/23
+    - 75.126.64.0/18
+    - 75.127.0.0/16
+    - 75.128.0.0/9
+    - 76.0.0.0/6
+    - 80.0.0.0/4
+    - 96.0.0.0/4
     dst_ns:
     - None
     dst_pods:


### PR DESCRIPTION
fixes issue #205 

- Added new query test within `tests/calico_testcases/example_policies/testcase16-nets/testcase16-scheme.yaml` , relevant for this issue.
- Moved the methods of disjoint ip-blocks into the IpBlock class, so that it is also used in ConnectivityMapQuery
- Fixed another issue of labels considered for fw-rules: adding the allowed labels as referenced labels from each policy through `add_policy` , so that for example labels are also added for configs generated from `clone_with_just_one_policy`.
- Added `.gitattributes` file to allow diffing dot files.
