### PR TITLE
package setup files

### DIFF
--- a/network-config-analyzer/__init__.py
+++ b/network-config-analyzer/__init__.py
@@ -1,4 +1,4 @@
 import sys
 import os
 
-sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))  # TODO: Use proper library imports instead

--- a/network-config-analyzer/__init__.py
+++ b/network-config-analyzer/__init__.py
@@ -2,4 +2,3 @@ import sys
 import os
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-

--- a/network-config-analyzer/__init__.py
+++ b/network-config-analyzer/__init__.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = network-config-analyzer
-version = 1.3.9
+version = 1.3.1
 author = Ziv Nevo
 author_email = nevo@il.ibm.com
 description = An analyzer for Network Policies and other connectivity-configuration resources
@@ -32,4 +32,3 @@ python_requires = >=3.8
 [options.entry_points]
 console_scripts =
         nca = nca.nca:nca_main
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,35 @@
+[metadata]
+name = network-config-analyzer
+version = 1.3.9
+author = Ziv Nevo
+author_email = nevo@il.ibm.com
+description = An analyzer for Network Policies and other connectivity-configuration resources
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/IBM/network-config-analyzer
+project_urls =
+    Bug Tracker = https://github.com/IBM/network-config-analyzer/issues
+    NP-Guard Home = https://np-guard.github.io
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+
+[options]
+packages = 
+    nca
+package_dir =
+    nca = network-config-analyzer
+install_requires = 
+    PyGithub==1.54.1
+    ruamel.yaml==0.17.21
+    Flask==2.1.1
+    PyYAML==6.0
+    greenery==3.3.7
+
+python_requires = >=3.8
+
+[options.entry_points]
+console_scripts =
+        nca = nca.nca:nca_main
+


### PR DESCRIPTION
This should allow users to run `pip install network-config-analyzer` and then simply run `nca`.
Comments:
- I already uploaded version 1.3.1 to PyPi, so this should already work.
- `pip install` will fail if the installed python version is less than 3.8
- Some installations (e.g., Ubuntu, RHEL) require running `pip3` instead of `pip`
- If the user is not `root`/`admin` and does not use `sudo` when running `pip`, `nca` is installed under the user's home directory. In Linux, this is usually under ` ~/.local/bin`. In Windows, this is usually under `~/AppData/Roaming/Python/Python39/Scripts`. PATH must be set to this directory if we want to simply run `nca` from the command-line.
- An alternative, safer way is to use a virtual environment:
  1. `python3 -m venv venv`
  2. `source venv/bin/activate`
  3. `pip install network-config-analyzer`
  4. `nca -h`

**Note**: Currently dependencies appear in both `requirements.txt` and `setup.cfg`. We should find a way to avoid this duplication.