### PR TITLE
assign ns_finder to pods_finder before loading calico peers

### DIFF
--- a/network-config-analyzer/ResourcesHandler.py
+++ b/network-config-analyzer/ResourcesHandler.py
@@ -279,6 +279,7 @@ class ResourcesParser:
         if ResourceType.Namespaces in resource_flags:
             self.ns_finder.load_ns_from_live_cluster()
         if ResourceType.Pods in resource_flags:
+            self.pods_finder.namespaces_finder = self.ns_finder
             self.pods_finder.load_peer_from_calico_resource()
         if ResourceType.Policies in resource_flags:
             self.policies_finder.load_policies_from_calico_cluster()


### PR DESCRIPTION
#240 
Hi @zivnevo , 
unfortunately, I couldn't run "calicoctl" successfully on my local workspace yet.
I think the bug occurred because of a "missing" assignment of namespaces_finder before loading calico pods. (fixed in this commit)
Can you please re-run the cmdline with this branch to check if the bug fixed? 
thanks