### PR TITLE
values syntax checking in matchexpression selector in k8s networkpolicy

### DIFF
--- a/network-config-analyzer/K8sPolicyYamlParser.py
+++ b/network-config-analyzer/K8sPolicyYamlParser.py
@@ -103,11 +103,11 @@ class K8sPolicyYamlParser(GenericYamlParser):
             self.syntax_error(f'value label of "{key}" can not be null', key_container)
         if val:
             if len(val) > 63:
-                self.syntax_error(f'invalid value in "{key}: {val}", a label value must be no more than 63 characters',
+                self.syntax_error(f'invalid value "{val}" for "{key}", a label value must be no more than 63 characters',
                                   key_container)
             pattern = r"(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?"
             if re.fullmatch(pattern, val) is None:
-                self.syntax_error(f'invalid value in "{key}: {val}", value label must be an empty string or consist'
+                self.syntax_error(f'invalid value "{val}" for "{key}", value label must be an empty string or consist'
                                   f' of alphanumeric characters, "-", "_" or ".", and must start and end with an '
                                   f'alphanumeric character ', key_container)
 
@@ -129,6 +129,8 @@ class K8sPolicyYamlParser(GenericYamlParser):
             values = requirement.get('values')
             if not values:
                 self.syntax_error('A requirement with In/NotIn operator but without values', requirement)
+            for value in values:
+                self.check_label_value_syntax(value, key, requirement)
             action = self.FilterActionType.In if operator == 'In' else self.FilterActionType.NotIn
             if namespace_selector:
                 return self.peer_container.get_namespace_pods_with_label(key, values, action)

--- a/tests/k8s_testcases/network-policy-checks-bad-path/matchexpressions_values_wrong_form.yaml
+++ b/tests/k8s_testcases/network-policy-checks-bad-path/matchexpressions_values_wrong_form.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: matchexpressions-values-test-form
+  namespace: kube-system
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: NotIn
+        # wrong form
+        values:
+          Abc-_.
+  policyTypes:
+    - Ingress
+    - Egress

--- a/tests/k8s_testcases/network-policy-checks-bad-path/network-policy-check-bad-path-scheme.yaml
+++ b/tests/k8s_testcases/network-policy-checks-bad-path/network-policy-check-bad-path-scheme.yaml
@@ -263,6 +263,11 @@ networkConfigList:
       - matchexpressions_values_wrong_type.yaml
     expectedError: 1
 
+  - name: matchexpressions_values_wrong_form
+    networkPolicyList:
+      - matchexpressions_values_wrong_form.yaml
+    expectedError: 1
+
   - name: matchexpressions_values_no_match_with_operator
     networkPolicyList:
       - matchexpressions_values_no_match_with_operator.yaml


### PR DESCRIPTION
while working on [baseline-rules syntax check issue](https://github.com/np-guard/baseline-rules/issues/11),
I realized that in K8sPolicyYamlParser.py, the syntax check of labels' value is missing in case of match-expression selector form.
So added it with a matching test