### PR TITLE
Modifications to Dockerfile to make the image more secure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,20 @@
 #
 
 # Using python:3.8-slim
-FROM python@sha256:d82f9b8300f1ab29b3a940b1a2dcf4590db5213ed1053ea49b44898367d38cf3
+FROM python@sha256:726098870bb14355cb12572764a3be191b42f8b15947d97affe3b8ec6a7a446e
 
-RUN python -m pip install -U pip wheel setuptools
 COPY requirements.txt /nca/
-RUN pip install -r /nca/requirements.txt
+RUN python -m pip install -U pip wheel setuptools && pip install -r /nca/requirements.txt
 
-RUN apt-get update && apt-get install curl -y
+RUN apt-get update && apt-get install curl -y && rm -rf /var/lib/apt/lists
 
-RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" --output /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
+RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" --output /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl
 
-RUN curl -L https://github.com/projectcalico/calicoctl/releases/download/v3.3.1/calicoctl --output /usr/local/bin/calicoctl
-RUN chmod +x /usr/local/bin/calicoctl
+RUN curl -L https://github.com/projectcalico/calicoctl/releases/download/v3.3.1/calicoctl --output /usr/local/bin/calicoctl \
+    && chmod +x /usr/local/bin/calicoctl
+
+RUN apt-get purge curl -y && apt-get autoremove -y
 
 COPY network-config-analyzer/ /nca/
 


### PR DESCRIPTION
* Upgrade to the latest version of the base image (python:3.8-slim)
* Reduce the number of image layers by merging related RUN commands together
* Removing apt cache (see [here](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005))
* Remove curl and its dependencies from the image
Signed-off-by: Ziv Nevo <nevo@il.ibm.com>