### PR TITLE
ignore errors to communicate with live cluster if it is not an explicit requirement

### DIFF
--- a/docs/CommonQueryPatterns.md
+++ b/docs/CommonQueryPatterns.md
@@ -14,7 +14,8 @@ Patterns describing how to combine specific switches (global: `--<query_name> , 
 `--<query_name> --resource_list <networkPolicies, namespaces and pods paths> --base_resource_list <networkpolicies, namespaces and pods path>` [see example here](../tests/k8s_cmdline_tests.yaml#L293-L302)
 
 ##### Handling missing resources:
-- When running without any switch (i.e. `--<query_name>`), all resources will be loaded from k8s live cluster.
+- When running without any switch (i.e. `--<query_name>`), nca checks if a communication with k8s live cluster is available, if yes - resources will be loaded from k8s live cluster, 
+otherwise, the query runs on empty resources (empty query result)
 
 Running with switches:
 - When running with specific topology switches only (using only `pod_list` and `ns_list`) without providing networkPolicy path, policies will be loaded from k8s live cluster
@@ -47,7 +48,8 @@ Running with switches:
     `resourceList: [list of networkPolicies, namespaces and pods paths]` [see example here ](../tests/k8s_testcases/example_policies/resourcelist-one-path-example/resource-path-scheme.yaml#L3-L7)
 
 ##### Handling missing resources:
-- If global scope does not exist, topology objects will be loaded from k8s live cluster.
+- If global scope does not exist, nca checks if a communication with k8s live cluster is available, if yes - topology resources will be loaded from k8s live cluster, 
+otherwise, an empty peer container is created
 - If `networkPolicyList` is not used and `resourceList` does not refer to any policy, a query reading this considers empty network-policies list.
 - If global pods are missing (i.e. `podList` is not used and `resourceList` does not refer to any pod), global cluster will have 0 endpoints. 
 - If config's pods are missing, global pods will be used

--- a/nca/Utils/CmdlineRunner.py
+++ b/nca/Utils/CmdlineRunner.py
@@ -21,18 +21,19 @@ class CmdlineRunner:
     ignore_live_cluster_err = False
 
     @staticmethod
-    def run_and_get_output(cmdline_list):
+    def run_and_get_output(cmdline_list, helm_flag=False):
         """
         Run an executable with specific arguments and return its output to stdout
         if a communicate error occurs, it will be ignored in case this is a silent try to communicate with live cluster,
         otherwise, will be printed to stderr
         :param list[str] cmdline_list: A list of arguments, the first of which is the executable path
+        :param helm_flag: indicates if the executable is helm - communicate errors are always considered for helm
         :return: The executable's output to stdout ( a list-resources on success, otherwise empty value)
         :rtype: str
         """
         cmdline_process = subprocess.Popen(cmdline_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = cmdline_process.communicate()
-        if err and not CmdlineRunner.ignore_live_cluster_err:
+        if err and (not CmdlineRunner.ignore_live_cluster_err or helm_flag):
             print(err.decode().strip('\n'), file=sys.stderr)
         return out
 
@@ -104,4 +105,4 @@ class CmdlineRunner:
         :return: The resolved yaml files generated from the chart file
         """
         cmdline_list = ['helm', 'template', 'nca-extract', chart_dir]
-        return CmdlineRunner.run_and_get_output(cmdline_list)
+        return CmdlineRunner.run_and_get_output(cmdline_list, helm_flag=True)

--- a/nca/Utils/CmdlineRunner.py
+++ b/nca/Utils/CmdlineRunner.py
@@ -34,8 +34,8 @@ class CmdlineRunner:
         """
         cmdline_process = subprocess.Popen(cmdline_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = cmdline_process.communicate()
-        print_err_flag = not check_for_silent_exec or \
-                         (check_for_silent_exec and not CmdlineRunner.ignore_live_cluster_err)
+        print_err_flag = \
+            not check_for_silent_exec or (check_for_silent_exec and not CmdlineRunner.ignore_live_cluster_err)
         if err and print_err_flag:
             print(err.decode().strip('\n'), file=sys.stderr)
         return out

--- a/tests/k8s_testcases/example_policies/demo_short/demo2-scheme.yaml
+++ b/tests/k8s_testcases/example_policies/demo_short/demo2-scheme.yaml
@@ -1,8 +1,7 @@
-namespaceList: ../../example_podlist/ns_list.json
-podList: ../../example_podlist/pods_list.json
-
 networkConfigList:
   - name: sanity_np2
+    namespaceList: ../../example_podlist/ns_list.json
+    podList: ../../example_podlist/pods_list.json
     networkPolicyList:
       - sanity2-networkpolicy.yaml
     expectedWarnings: 0


### PR DESCRIPTION
#351
any implicit attempt to load from k8s live cluster will occur silently
explicit attempts (e.g. k8s is an input resource) - runs as usual (communication errors are not ignored)
Signed-off-by: shireenf-ibm <shireenf@il.ibm.com>