### PR TITLE
Fix path for .github/actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
-    directory: "/.github/actions"
+    directory: ".github/actions/setup-nca-env"
     schedule:
       interval: "weekly"
   - package-ecosystem: "pip"


### PR DESCRIPTION
Dependabot still fails to analyze `.github/actions/setup-nca-env/action.yml`, probably because the path is wrong.