### PR TITLE
istio live cluster tests

### DIFF
--- a/nca/Parsers/GenericYamlParser.py
+++ b/nca/Parsers/GenericYamlParser.py
@@ -153,7 +153,6 @@ class GenericYamlParser:
         if kind not in object_kind:
             return None, None  # Not the relevant object
         api_version = yaml_object.get('apiVersion')
-        print(f'api_version field is {api_version} in {kind}')
         version_keywords = [layer_keywords] if not isinstance(layer_keywords, list) else layer_keywords
         if not any(keyword in api_version for keyword in version_keywords):
             return None, None  # apiVersion is not properly set

--- a/nca/Parsers/GenericYamlParser.py
+++ b/nca/Parsers/GenericYamlParser.py
@@ -153,6 +153,7 @@ class GenericYamlParser:
         if kind not in object_kind:
             return None, None  # Not the relevant object
         api_version = yaml_object.get('apiVersion')
+        print(f'api_version field is {api_version}')
         version_keywords = [layer_keywords] if not isinstance(layer_keywords, list) else layer_keywords
         if not any(keyword in api_version for keyword in version_keywords):
             return None, None  # apiVersion is not properly set

--- a/nca/Parsers/GenericYamlParser.py
+++ b/nca/Parsers/GenericYamlParser.py
@@ -153,7 +153,7 @@ class GenericYamlParser:
         if kind not in object_kind:
             return None, None  # Not the relevant object
         api_version = yaml_object.get('apiVersion')
-        print(f'api_version field is {api_version}')
+        print(f'api_version field is {api_version} in {kind}')
         version_keywords = [layer_keywords] if not isinstance(layer_keywords, list) else layer_keywords
         if not any(keyword in api_version for keyword in version_keywords):
             return None, None  # apiVersion is not properly set

--- a/nca/Parsers/IstioPolicyYamlParser.py
+++ b/nca/Parsers/IstioPolicyYamlParser.py
@@ -529,7 +529,8 @@ class IstioPolicyYamlParser(IstioGenericYamlParser):
         :rtype: IstioNetworkPolicy
         """
         policy_name, policy_ns = self.parse_generic_yaml_objects_fields(self.policy, ['AuthorizationPolicy'],
-                                                                        ['security.istio.io/v1beta1'], 'istio')
+                                                                        ['security.istio.io/v1beta1', 'security.istio.io/v1'],
+                                                                        'istio')
         if policy_name is None:
             return None  # not an Istio AuthorizationPolicy
         warn_if_missing = policy_ns != istio_root_namespace

--- a/nca/Parsers/IstioSidecarYamlParser.py
+++ b/nca/Parsers/IstioSidecarYamlParser.py
@@ -171,7 +171,7 @@ class IstioSidecarYamlParser(IstioGenericYamlParser):
         sidecar_spec = self.policy['spec']
         # currently, supported fields in spec are workloadSelector and egress
         allowed_spec_keys = {'workloadSelector': [0, dict], 'ingress': [3, list], 'egress': [0, list],
-                             'outboundTrafficPolicy': [3, str]}
+                             'outboundTrafficPolicy': [3, dict]}
         self.check_fields_validity(sidecar_spec, 'Sidecar spec', allowed_spec_keys)
         res_policy.affects_egress = sidecar_spec.get('egress') is not None
 


### PR DESCRIPTION
after downloading istio 1.17 version, istio live cluster tests fail with `apiVersion has invalid value in AuthorizationPolicy` error
from a debug , seems that the new apiVersion of AuthorizationPolicy is `security.istio.io/v1` -> updated accordingly
